### PR TITLE
メールタイトル作成関数の実装

### DIFF
--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -69,6 +69,23 @@ def make_compared_result_list() -> list[ComparedResult]:
     return compared_result_list
 
 
+def make_title(compared_results: list[ComparedResult]) -> str:
+    # 閾値を超えた商品のリストを作成
+    product_exceed_thd: list[Product] = [
+        compared_result.product
+        for compared_result in compared_results
+        if compared_result.is_exceed_thd
+    ]
+
+    # メールのタイトルを作成
+    if product_exceed_thd:
+        mail_title: str = f"【お知らせ】{ ', '.join([product.name for product in product_exceed_thd])}で急激な価格の上昇がありました。"
+    else:
+        mail_title: str = "【お知らせ】急激な価格の上昇はありませんでした。"
+
+    return mail_title
+
+
 def japanize_percentage(percentage: float) -> str:
     suffix = "上昇" if percentage > 0 else "減少"
     return f"{int(abs(percentage))}%" + suffix

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -69,7 +69,7 @@ def make_compared_result_list() -> list[ComparedResult]:
     return compared_result_list
 
 
-def make_title(compared_results: list[ComparedResult]) -> str:
+def make_mail_title(compared_results: list[ComparedResult]) -> str:
     # 閾値を超えた商品のリストを作成
     product_exceed_thd: list[Product] = [
         compared_result.product
@@ -81,7 +81,3 @@ def make_title(compared_results: list[ComparedResult]) -> str:
     if product_exceed_thd:
         return f"【お知らせ】{ ', '.join([product.name for product in product_exceed_thd])}で急激な価格の上昇がありました。"
     return "【お知らせ】急激な価格の上昇はありませんでした。"
-    else:
-        mail_title: str = "【お知らせ】急激な価格の上昇はありませんでした。"
-
-    return mail_title

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -70,13 +70,14 @@ def make_compared_result_list() -> list[ComparedResult]:
 
 
 def make_mail_title(compared_results: list[ComparedResult]) -> str:
-    # ユーザー設定の閾値を超えた商品のリストを作成
     products_exceed_thd: list[Product] = [
         compared_result.product
         for compared_result in compared_results
         if compared_result.is_exceed_thd
     ]
 
-    if len(products_exceed_thd) > 0:
-        return f"【お知らせ】{ ', '.join(products_exceed_thd)}で急激な価格の上昇がありました。"
-    return "【お知らせ】急激な価格の上昇はありませんでした。"
+    if len(products_exceed_thd) == 0:
+        return "【お知らせ】急激な価格の上昇はありませんでした。"
+    return (
+        f"【お知らせ】{ ', '.join(products_exceed_thd)}で急激な価格の上昇がありました。"
+    )

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -69,7 +69,7 @@ def make_compared_result_list() -> list[ComparedResult]:
     return compared_result_list
 
 
-def make_title(compared_results: list[ComparedResult]) -> str:
+def make_mail_title(compared_results: list[ComparedResult]) -> str:
     # 閾値を超えた商品のリストを作成
     product_exceed_thd: list[Product] = [
         compared_result.product
@@ -81,65 +81,3 @@ def make_title(compared_results: list[ComparedResult]) -> str:
     if product_exceed_thd:
         return f"【お知らせ】{ ', '.join([product.name for product in product_exceed_thd])}で急激な価格の上昇がありました。"
     return "【お知らせ】急激な価格の上昇はありませんでした。"
-    else:
-        mail_title: str = "【お知らせ】急激な価格の上昇はありませんでした。"
-
-    return mail_title
-
-
-def japanize_percentage(percentage: float) -> str:
-    suffix = "上昇" if percentage > 0 else "減少"
-    return f"{int(abs(percentage))}%" + suffix
-
-
-def make_mail_body(compared_results: list[ComparedResult]) -> str:
-    user_config = get_user_config()
-
-    now_hour = datetime.now().hour
-
-    def make_trading_timing_txt(hour: int):
-        return f"本日の{hour}時時点での取引価格によるお知らせです。"
-
-    def make_exceed_txt(compared_results: list[ComparedResult]) -> str:
-        if len(compared_results) == 0:
-            return ""
-
-        exceed_header = "価格の急激な上昇が確認された商品"
-
-        def make_body(compared_result: ComparedResult) -> str:
-            return f"・{compared_result.product}。\n現在の取引価格は約{int(compared_result.current_price)}円です。急激な価格の上昇が起きています。過去{user_config.period_days}日間の平均価格と比較して、{japanize_percentage(compared_result.increase_price_percentage)}しています。"
-
-        exceed_body = "\n\n".join([make_body(c) for c in compared_results])
-
-        return exceed_header + "\n" + exceed_body
-
-    def make_unexceed_txt(compared_results: list[ComparedResult]) -> str:
-        if len(compared_results) == 0:
-            return ""
-
-        unexceed_header = "価格の急激な上昇が確認されなかった商品"
-
-        def make_body(compared_result: ComparedResult) -> str:
-            return f"・{compared_result.product}。\n現在の取引価格は約{int(compared_result.current_price)}円です。過去{user_config.period_days}日間の平均価格と比較して、{japanize_percentage(compared_result.increase_price_percentage)}しています。"
-
-        unexceed_body = "\n\n".join([make_body(c) for c in compared_results])
-        return unexceed_header + "\n" + unexceed_body
-
-    footer_txt = (
-        f"現在の閾値は{user_config.threshold_increase_rate_price}%です。閾値の変更は、以下のURLのReadmeをお読みください。"
-        + "\n"
-        + "https://github.com/Mkamono/box-over-looker"
-    )
-
-    return "\n\n".join(
-        [
-            s
-            for s in [
-                make_trading_timing_txt(now_hour),
-                make_exceed_txt([c for c in compared_results if c.is_exceed_thd]),
-                make_unexceed_txt([c for c in compared_results if not c.is_exceed_thd]),
-                footer_txt,
-            ]
-            if s != ""
-        ]
-    )

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -79,7 +79,8 @@ def make_title(compared_results: list[ComparedResult]) -> str:
 
     # メールのタイトルを作成
     if product_exceed_thd:
-        mail_title: str = f"【お知らせ】{ ', '.join([product.name for product in product_exceed_thd])}で急激な価格の上昇がありました。"
+        return f"【お知らせ】{ ', '.join([product.name for product in product_exceed_thd])}で急激な価格の上昇がありました。"
+    return "【お知らせ】急激な価格の上昇はありませんでした。"
     else:
         mail_title: str = "【お知らせ】急激な価格の上昇はありませんでした。"
 

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -77,7 +77,6 @@ def make_mail_title(compared_results: list[ComparedResult]) -> str:
         if compared_result.is_exceed_thd
     ]
 
-    # メールのタイトルを作成
     if len(products_exceed_thd) > 0:
         return f"【お知らせ】{ ', '.join(products_exceed_thd)}で急激な価格の上昇がありました。"
     return "【お知らせ】急激な価格の上昇はありませんでした。"

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -70,7 +70,7 @@ def make_compared_result_list() -> list[ComparedResult]:
 
 
 def make_mail_title(compared_results: list[ComparedResult]) -> str:
-    # 閾値を超えた商品のリストを作成
+    # ユーザー設定の閾値を超えた商品のリストを作成
     products_exceed_thd: list[Product] = [
         compared_result.product
         for compared_result in compared_results
@@ -78,6 +78,6 @@ def make_mail_title(compared_results: list[ComparedResult]) -> str:
     ]
 
     # メールのタイトルを作成
-    if products_exceed_thd:
-        return f"【お知らせ】{ ', '.join([product for product in products_exceed_thd])}で急激な価格の上昇がありました。"
+    if len(products_exceed_thd) > 0:
+        return f"【お知らせ】{ ', '.join(products_exceed_thd)}で急激な価格の上昇がありました。"
     return "【お知らせ】急激な価格の上昇はありませんでした。"

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -69,15 +69,18 @@ def make_compared_result_list() -> list[ComparedResult]:
     return compared_result_list
 
 
-def make_mail_title(compared_results: list[ComparedResult]) -> str:
-    products_exceed_thd: list[Product] = [
+def make_title(compared_results: list[ComparedResult]) -> str:
+    # 閾値を超えた商品のリストを作成
+    product_exceed_thd: list[Product] = [
         compared_result.product
         for compared_result in compared_results
         if compared_result.is_exceed_thd
     ]
 
-    if len(products_exceed_thd) == 0:
-        return "【お知らせ】急激な価格の上昇はありませんでした。"
-    return (
-        f"【お知らせ】{ ', '.join(products_exceed_thd)}で急激な価格の上昇がありました。"
-    )
+    # メールのタイトルを作成
+    if product_exceed_thd:
+        mail_title: str = f"【お知らせ】{ ', '.join([product.name for product in product_exceed_thd])}で急激な価格の上昇がありました。"
+    else:
+        mail_title: str = "【お知らせ】急激な価格の上昇はありませんでした。"
+
+    return mail_title

--- a/backend/src/mail.py
+++ b/backend/src/mail.py
@@ -71,13 +71,13 @@ def make_compared_result_list() -> list[ComparedResult]:
 
 def make_mail_title(compared_results: list[ComparedResult]) -> str:
     # 閾値を超えた商品のリストを作成
-    product_exceed_thd: list[Product] = [
+    products_exceed_thd: list[Product] = [
         compared_result.product
         for compared_result in compared_results
         if compared_result.is_exceed_thd
     ]
 
     # メールのタイトルを作成
-    if product_exceed_thd:
-        return f"【お知らせ】{ ', '.join([product.name for product in product_exceed_thd])}で急激な価格の上昇がありました。"
+    if products_exceed_thd:
+        return f"【お知らせ】{ ', '.join([product for product in products_exceed_thd])}で急激な価格の上昇がありました。"
     return "【お知らせ】急激な価格の上昇はありませんでした。"


### PR DESCRIPTION
## やったこと
<!-- このプルリクで何をしたのか？ -->
メールタイトル作成関数の実装

## やらないこと
<!-- このプルリクでやらないことは何か？ -->


## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
![image](https://github.com/Mkamono/box-over-looker/assets/144202943/6f384050-5f5d-48fb-8303-feb1c6cbbfc5)


## 疑問点
<!-- 分からなかったこと、懸念点 -->


## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
メール作成関数自体がかなーり長くなったので、タイトル作成関数とメール本文作成関数に切り出した
最後にメール作成関数として↑2つを使って実装
https://www.notion.so/89251530b4db434c891e83d98f847366
## セルフレビュー

- [x] 型指定をした
- [x] マジックナンバーはない
- [x] 変数名、関数名は分かりやすく、内容とあっている
- [x] テスト記載が残っていない
- [x] 相互依存がない
- [x] 早期リターン
- [ ] 全てのエラーキャッチ
- [ ] 説明変数
- [x] 不要な変更はない
- [x] 命名規則に則っている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 特定の閾値を超える商品に基づいてメールタイトルを生成する機能が追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->