### PR TITLE
メールアドレスをユーザーが設定していない場合、エラーを出す

### DIFF
--- a/backend/src/error.py
+++ b/backend/src/error.py
@@ -1,2 +1,6 @@
 class NoRecordError(Exception):
     pass
+
+
+class NoAddressError(Exception):
+    pass

--- a/backend/src/user_config.py
+++ b/backend/src/user_config.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 
+from error import NoAddressError
 from pydantic import BaseModel, Field
 
 
@@ -16,6 +17,10 @@ class UserConfig(BaseModel):
     threshold_increase_rate_price: float = Field(alias="価格の増加倍率(%)")
     notification_timing: NotificationTiming = Field(alias="通知時間")
     period_days: int = Field(alias="価格の過去データの日数")
+
+    def model_post_init(self):
+        if self.mail == "your_email_address@sample.com":
+            raise NoAddressError("メールアドレスを設定してください")
 
 
 def get_user_config() -> UserConfig:


### PR DESCRIPTION
## やったこと
<!-- このプルリクで何をしたのか？ -->
メールアドレスが入ってない時のエラー作成
user_configのメソッドに、メールアドレスを確認する関数の実装

## やらないこと
<!-- このプルリクでやらないことは何か？ -->


## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->


## 疑問点
<!-- 分からなかったこと、懸念点 -->


## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
## セルフレビュー

- [ ] 型指定をした
- [ ] マジックナンバーはない
- [ ] 変数名、関数名は分かりやすく、内容とあっている
- [ ] テスト記載が残っていない
- [ ] 相互依存がない
- [ ] 早期リターン
- [ ] 全てのエラーキャッチ
- [ ] 説明変数
- [ ] 不要な変更はない
- [ ] 命名規則に則っている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザー設定でデフォルトのメールアドレスが使用されている場合にエラーを通知する機能を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->