### PR TITLE
Backend：TimeZoneをUTCからJSTに変更

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install -r /tmp/requirements.txt
 
 COPY user_config.jsonc ./
 COPY backend/src ./src
-RUN apt-get install -y tzdata && \
-    ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+
+ENV TZ="Asia/Tokyo"
 
 CMD ["python", "./src/main.py"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,7 @@ RUN pip install -r /tmp/requirements.txt
 
 COPY user_config.jsonc ./
 COPY backend/src ./src
+RUN apt-get install -y tzdata && \
+    ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
 CMD ["python", "./src/main.py"]


### PR DESCRIPTION
## やったこと
<!-- このプルリクで何をしたのか？ -->
TimeZoneをUTCからJSTに変更

## やらないこと
<!-- このプルリクでやらないことは何か？ -->


## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
composeのバックエンド内にて
![image](https://github.com/Mkamono/box-over-looker/assets/144202943/2528d219-a83d-4c40-9029-b232f2464761)


## 疑問点
<!-- 分からなかったこと、懸念点 -->


## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
参考資料
https://crypto-nft-fire.com/docker-timezone/

## セルフレビュー

- [ ] 型指定をした
- [ ] マジックナンバーはない
- [ ] 変数名、関数名は分かりやすく、内容とあっている
- [ ] テスト記載が残っていない
- [ ] 相互依存がない
- [ ] 早期リターン
- [ ] 全てのエラーキャッチ
- [ ] 説明変数
- [ ] 不要な変更はない
- [ ] 命名規則に則っている


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- アプリケーションのタイムゾーンを「アジア/東京」に設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->